### PR TITLE
Add bottom field to avoid container overflow

### DIFF
--- a/src/components/field-outlined/index.js
+++ b/src/components/field-outlined/index.js
@@ -8,9 +8,10 @@ export default class OutlinedTextField extends TextField {
   static contentInset = {
     ...TextField.contentInset,
 
-    input: 16,
-
+    input: 10,
+    
     top: 0,
+    bottom:0,
     left: 12,
     right: 12,
   };


### PR DESCRIPTION
By changing input from 16 to 10 and bottom = 0. ContainerStyles will not overflow